### PR TITLE
Add ability to query extended tweets

### DIFF
--- a/twitter_dl/__init__.py
+++ b/twitter_dl/__init__.py
@@ -1,4 +1,4 @@
 from .downloader import Downloader
 from .threaded_aio_dlder import AioDownloader
 
-version = "0.2.0"
+version = "0.2.1"

--- a/twitter_dl/downloader.py
+++ b/twitter_dl/downloader.py
@@ -55,11 +55,11 @@ class Downloader:
             raise RuntimeError("Bearer TokenNot Fetched")
 
     def download_media_of_tweet(self, tid, save_dest, size="large", include_video=False, 
-            include_photo=True):
+            include_photo=True, is_extended=False):
         ''' '''    
         save_dest = ensure_dir(save_dest)
 
-        tweet = self.get_tweet(tid)
+        tweet = self.get_tweet(tid, is_extended)
         self.process_tweet(tweet, save_dest, size, include_video, include_photo)
 
     def download_media_of_user(self, user, save_dest, size="large", limit=3200, rts=False, 
@@ -165,25 +165,28 @@ class Downloader:
         
         return self.api_fetch_tweets(apiurl, payload, start, count, rts, since_id)
 
-    def get_tweet(self, id):
+    def get_tweet(self, tid, is_extended=False):
         """Download single tweet
 
         Args:
-            id: Tweet ID.
+            tid: Tweet ID.
+            is_extended: extended tweet mode
         """
 
         bearer_token = self.bearer_token
         url = "https://api.twitter.com/1.1/statuses/show.json"
         headers = {"Authorization": f"Bearer {bearer_token}"}
-        payload = {"id": id, "include_entities": "true"}
-
+        payload = {"id": tid, "include_entities": "true"}
+        if is_extended:
+            self.log.info("Extended mode")
+            payload["tweet_mode"] = "extended"
         # get the request
         r = requests.get(url, headers=headers, params=payload)
 
         # check the response
         if r.status_code == 200:
             tweet = r.json()
-            self.log.info(f"Got tweet with id {id} of user @{tweet['user']['name']}")
+            self.log.info(f"Got tweet with id {tid} of user @{tweet['user']['name']}")
             return tweet
         else:
             self.log.error(f"{url} error, code was {r.status_code}")

--- a/twitter_dl/downloader.py
+++ b/twitter_dl/downloader.py
@@ -214,9 +214,7 @@ class Downloader:
         Args:
             tweet: A dict object representing a tweet.
         """
-        extended = tweet.get("entities")
-        if "media" not in extended:
-            extended = tweet.get("extended_entities")
+        extended = tweet.get("extended_entities")
         if not extended:
             return []
 

--- a/twitter_dl/downloader.py
+++ b/twitter_dl/downloader.py
@@ -55,12 +55,12 @@ class Downloader:
             raise RuntimeError("Bearer TokenNot Fetched")
 
     def download_media_of_tweet(self, tid, save_dest, size="large", include_video=False, 
-            include_photo=True, is_extended=False):
+            include_photo=True, is_extended=False, goto_quoted=False):
         ''' '''    
         save_dest = ensure_dir(save_dest)
 
         tweet = self.get_tweet(tid, is_extended)
-        self.process_tweet(tweet, save_dest, size, include_video, include_photo)
+        self.process_tweet(tweet, save_dest, size, include_video, include_photo, goto_quoted)
 
     def download_media_of_user(self, user, save_dest, size="large", limit=3200, rts=False, 
         include_video=False, include_photo=True, since_id=0):
@@ -192,11 +192,11 @@ class Downloader:
             self.log.error(f"{url} error, code was {r.status_code}")
             return None
 
-    def process_tweet(self, tweet, save_dest, size="large", include_video=False, include_photo=True):
+    def process_tweet(self, tweet, save_dest, size="large", include_video=False, include_photo=True, goto_quoted=False):
         if 'retweeted_status' in tweet:
             tweet = tweet['retweeted_status']
             self.log.debug('this is a retweet, turn to orignal tweet')
-        elif ("quoted_status" in tweet):
+        elif ("quoted_status" in tweet) and goto_quoted:
             tweet = tweet['quoted_status']
             self.log.debug('this is a quoted tweet, turn to orignal tweet')
 
@@ -214,10 +214,12 @@ class Downloader:
         Args:
             tweet: A dict object representing a tweet.
         """
-        extended = tweet.get("extended_entities")
+        extended = tweet.get("entities")
+        if "media" not in extended:
+            extended = tweet.get("extended_entities")
         if not extended:
             return []
-        
+
         rv = []
         if "media" in extended:
             for x in extended["media"]:


### PR DESCRIPTION
If tweet has more than 140 symbols, media resources cannot be found without parameter `tweet_mode=extended`